### PR TITLE
feat(maxc): add browser-based OAuth login via `auth login --oauth`

### DIFF
--- a/src/maxc_cli/app.py
+++ b/src/maxc_cli/app.py
@@ -22,6 +22,7 @@ from .cache import LocalCache
 from .config import (
     AuthConfig,
     ExternalAuthConfig,
+    OAuthAuthConfig,
     TableDefinition,
     default_global_config_path,
     load_config,
@@ -3234,6 +3235,96 @@ class MaxCApp:
             ),
         )
         self.log("auth.login", envelope.status, envelope.metadata)
+        return envelope
+
+    def auth_login_oauth(
+        self,
+        *,
+        site_type: 'str' = "CN",
+        no_browser: 'bool' = False,
+        on_url: 'Any | None' = None,
+        project: 'str | None' = None,
+        endpoint: 'str | None' = None,
+        region_name: 'str | None' = None,
+        tunnel_endpoint: 'str | None' = None,
+        catalog_endpoint: 'str | None' = None,
+        no_validate: 'bool' = False,
+        target_config_path: 'Path | None' = None,
+        no_picker: 'bool' = False,
+        reselect: 'bool' = False,
+    ) -> 'Envelope':
+        """Browser OAuth login (aliyun CLI ``--mode OAuth`` equivalent).
+
+        Runs Authorization Code + PKCE, exchanges the OAuth token for a
+        temporary STS triple, then delegates to the standard login flow
+        (project picker, validation, persistence). OAuth tokens are persisted
+        so the oauth provider can refresh/exchange on later invocations.
+        """
+        from .oauth import exchange_sts, start_oauth_flow
+
+        tokens = start_oauth_flow(
+            site_type,
+            open_browser=not no_browser,
+            on_url=on_url,
+        )
+        sts = exchange_sts(site_type, tokens.access_token)
+
+        # Persist OAuth state up front (aliyun CLI writes tokens before the
+        # exchange completes), so an abandoned picker run does not lose them.
+        target_path = target_config_path or default_global_config_path()
+        pre_payload = load_config_mapping(target_path) if target_path.exists() else {}
+        pre_auth = AuthConfig.from_mapping(pre_payload.get("auth", {}) or {})
+        pre_auth.provider = "oauth"
+        pre_auth.access_id = sts.access_key_id
+        pre_auth.secret_access_key = sts.access_key_secret
+        pre_auth.security_token = sts.security_token
+        pre_auth.token_expires_at = sts.expiration_iso
+        pre_auth.oauth = OAuthAuthConfig(
+            site_type=site_type,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+            access_token_expire=tokens.expires_at,
+        )
+        pre_payload["auth"] = pre_auth.to_mapping()
+        save_config_mapping(target_path, pre_payload)
+
+        envelope = self.auth_login(
+            access_id=sts.access_key_id,
+            secret_access_key=sts.access_key_secret,
+            security_token=sts.security_token,
+            project=project,
+            endpoint=endpoint,
+            region_name=region_name,
+            tunnel_endpoint=tunnel_endpoint,
+            catalog_endpoint=catalog_endpoint,
+            no_validate=no_validate,
+            target_config_path=target_path,
+            no_picker=no_picker,
+            reselect=reselect,
+        )
+
+        if envelope.status == "success":
+            # auth_login persisted with provider="sts_token" and dropped the
+            # oauth block — restore the OAuth identity on the saved config.
+            payload = load_config_mapping(target_path)
+            saved_auth = AuthConfig.from_mapping(payload.get("auth", {}) or {})
+            saved_auth.provider = "oauth"
+            saved_auth.token_expires_at = sts.expiration_iso
+            saved_auth.oauth = pre_auth.oauth
+            payload["auth"] = saved_auth.to_mapping()
+            save_config_mapping(target_path, payload)
+
+            if isinstance(envelope.data, dict):
+                envelope.data["auth_type"] = "oauth"
+                envelope.data["oauth_site_type"] = site_type
+                envelope.data["token_expires_at"] = sts.expiration_iso
+        elif envelope.status == "pending" and envelope.agent_hints:
+            # Keep the OAuth flow in the suggested completion command.
+            for suggested in envelope.agent_hints.actions:
+                if suggested.command and suggested.command.startswith("maxc auth login --project"):
+                    suggested.command = suggested.command.replace(
+                        "maxc auth login --project", "maxc auth login --oauth --project", 1
+                    )
         return envelope
 
     def auth_login_external(

--- a/src/maxc_cli/auth_providers.py
+++ b/src/maxc_cli/auth_providers.py
@@ -145,6 +145,10 @@ def auth_settings_available(config: 'MaxCConfig') -> 'bool':
             return not missing_odps_settings(settings, auth_type="sts_token")
         if provider == "external":
             return not missing_odps_settings(settings, auth_type="external")
+        if provider == "oauth":
+            return config.auth.oauth.is_configured() and not missing_odps_settings(
+                settings, auth_type="access_key"
+            )
         return not missing_odps_settings(settings, auth_type="access_key")
     except ValidationError:
         return False
@@ -222,6 +226,47 @@ def resolve_auth_connection(
             account=account,
         )
 
+    if provider == "oauth":
+        # Lazy import keeps the base import graph free of webbrowser/socket.
+        from .oauth import ensure_oauth_sts
+
+        auth = auth_override or config.auth
+        # Persist refreshed/rotated tokens only when resolving from the real
+        # config file (not for in-memory auth_override probes).
+        config_sources = getattr(config, "sources", None) or []
+        persist_path = config_sources[0] if auth_override is None and config_sources else None
+        sts = ensure_oauth_sts(auth, config_path=persist_path)
+
+        if not (settings.get("project") or config.default_project) or not settings.get("endpoint"):
+            raise ValidationError(
+                "OAuth login is incomplete: project or endpoint missing.",
+                suggestion="Run `maxc auth login --oauth --project <project> --endpoint <endpoint>`.",
+            )
+        try:
+            from odps.accounts import StsAccount
+        except ImportError as exc:
+            raise FeatureUnavailableError("pyodps is not installed in the current environment.") from exc
+
+        account = StsAccount(sts.access_key_id, sts.access_key_secret, sts.security_token)
+        return ResolvedAuthConnection(
+            auth_type="oauth",
+            provider="oauth",
+            project=settings["project"] or config.default_project,
+            endpoint=settings["endpoint"] or "",
+            region_name=settings.get("region_name"),
+            tunnel_endpoint=settings.get("tunnel_endpoint"),
+            catalog_endpoint=settings.get("catalog_endpoint"),
+            access_id=sts.access_key_id,
+            secret_access_key=sts.access_key_secret,
+            security_token=sts.security_token,
+            token_expires_at=sts.expiration_iso,
+            identity_source="oauth",
+            settings=settings,
+            setting_sources=sources,
+            suppressed_env_vars=suppressed_env_vars,
+            account=account,
+        )
+
     missing = missing_odps_settings(settings, auth_type="access_key")
     if missing:
         raise ValidationError(
@@ -255,7 +300,7 @@ def infer_auth_provider(
 ) -> 'str':
     auth = auth_override or config.auth
     explicit = (auth.provider or settings.get("provider") or "").strip().lower()
-    if explicit in {"access_key", "sts_token", "sts", "external"}:
+    if explicit in {"access_key", "sts_token", "sts", "external", "oauth"}:
         if explicit == "sts":
             return "sts_token"
         return explicit
@@ -263,6 +308,10 @@ def infer_auth_provider(
     # handle it here as a safety net for direct callers.
     if explicit == "ncs":
         return "external"
+    # OAuth login caches the exchanged STS triple on the same AuthConfig, so
+    # this check must run before the security_token heuristic below.
+    if auth.oauth.is_configured():
+        return "oauth"
     if settings.get("security_token"):
         return "sts_token"
     if auth.external.is_configured() or settings.get("external_process_command"):
@@ -415,6 +464,11 @@ def list_ncs_accounts(account_type: 'str') -> 'dict[str, Any]':
 
 def build_auth_options(config_path: 'Path | None' = None) -> 'list[dict[str, Any]]':
     options = [
+        {
+            "type": "oauth",
+            "description": "Authenticate in the browser via Alibaba Cloud OAuth (Authorization Code + PKCE); credentials refresh automatically. Requires a RAM admin to have installed the official-cli OAuth application.",
+            "command": "auth login --oauth",
+        },
         {
             "type": "access_key",
             "description": "Authenticate with a long-lived access key.",

--- a/src/maxc_cli/cli.py
+++ b/src/maxc_cli/cli.py
@@ -514,6 +514,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Catalog endpoint URL for the bootstrap ODPS (override for non-China regions)",
     )
     auth_login.add_argument("--from-env", action="store_true", help="Import credentials from environment variables")
+    auth_login.add_argument(
+        "--oauth",
+        action="store_true",
+        help=(
+            "Authenticate in the browser via Alibaba Cloud OAuth (Authorization Code + PKCE), "
+            "equivalent to `aliyun configure --mode OAuth`. Credentials refresh automatically."
+        ),
+    )
+    auth_login.add_argument(
+        "--site-type",
+        choices=["CN", "INTL"],
+        default="CN",
+        help="OAuth site type (default: CN)",
+    )
+    auth_login.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the browser automatically; only print the sign-in URL",
+    )
     auth_login.add_argument("--no-validate", action="store_true", help="Skip credential validation")
     auth_login.add_argument(
         "--no-picker",
@@ -1482,6 +1501,26 @@ def _handle_auth_login(app: MaxCApp, args: argparse.Namespace, stdout: TextIO) -
                 f"`{flag}` cannot be empty.",
                 suggestion=f"Either omit `{flag}` to fall back to environment/config, or pass a non-empty value.",
             )
+    if args.oauth:
+        # Keep stdout a clean single envelope in --json mode: the sign-in URL
+        # goes to stderr, where a calling agent/plugin can scrape it.
+        url_sink = (lambda url: print(f"Sign-in URL: {url}", file=sys.stderr)) if _is_json_mode(args) else None
+        envelope = app.auth_login_oauth(
+            site_type=args.site_type,
+            no_browser=args.no_browser,
+            on_url=url_sink,
+            project=args.project,
+            endpoint=args.endpoint,
+            region_name=args.region_name,
+            tunnel_endpoint=args.tunnel_endpoint,
+            catalog_endpoint=args.catalog_endpoint,
+            no_validate=args.no_validate,
+            target_config_path=args.requested_config_path,
+            no_picker=args.no_picker,
+            reselect=args.reselect,
+        )
+        _emit_envelope(envelope, args=args, stdout=stdout, default_format="json")
+        return
     envelope = app.auth_login(
         access_id=args.access_id,
         secret_access_key=args.secret_access_key,

--- a/src/maxc_cli/config.py
+++ b/src/maxc_cli/config.py
@@ -169,6 +169,48 @@ class NcsAuthConfig:
 
 
 @dataclass
+class OAuthAuthConfig:
+    """Browser OAuth login state (aliyun CLI ``--mode OAuth`` equivalent).
+
+    Holds the OAuth token pair; the exchanged temporary STS triple is cached
+    in the regular ``access_id``/``secret_access_key``/``security_token`` +
+    ``token_expires_at`` fields of AuthConfig, mirroring how aliyun CLI writes
+    exchanged credentials back into the profile.
+    """
+
+    site_type: 'str | None' = None  # "CN" or "INTL"
+    access_token: 'str | None' = None
+    refresh_token: 'str | None' = None
+    access_token_expire: 'int | None' = None  # unix seconds
+
+    @classmethod
+    def from_mapping(cls, payload: 'dict[str, Any] | None') -> "OAuthAuthConfig":
+        payload = payload or {}
+        expire = payload.get("access_token_expire")
+        return cls(
+            site_type=_optional_string(payload.get("site_type")),
+            access_token=_optional_string(payload.get("access_token")),
+            refresh_token=_optional_string(payload.get("refresh_token")),
+            access_token_expire=int(expire) if expire is not None else None,
+        )
+
+    def to_mapping(self) -> 'dict[str, Any]':
+        payload: dict[str, Any] = {}
+        if self.site_type:
+            payload["site_type"] = self.site_type
+        if self.access_token:
+            payload["access_token"] = self.access_token
+        if self.refresh_token:
+            payload["refresh_token"] = self.refresh_token
+        if self.access_token_expire is not None:
+            payload["access_token_expire"] = self.access_token_expire
+        return payload
+
+    def is_configured(self) -> 'bool':
+        return bool(self.access_token or self.refresh_token)
+
+
+@dataclass
 class AuthConfig:
     provider: 'str | None' = None
     access_id: 'str | None' = None
@@ -182,6 +224,7 @@ class AuthConfig:
     catalog_endpoint: 'str | None' = None
     ncs: 'NcsAuthConfig' = field(default_factory=NcsAuthConfig)
     external: 'ExternalAuthConfig' = field(default_factory=ExternalAuthConfig)
+    oauth: 'OAuthAuthConfig' = field(default_factory=OAuthAuthConfig)
 
     @classmethod
     def from_mapping(cls, payload: 'dict[str, Any]') -> "AuthConfig":
@@ -206,6 +249,7 @@ class AuthConfig:
             catalog_endpoint=_optional_string(payload.get("catalog_endpoint")),
             ncs=NcsAuthConfig.from_mapping(payload.get("ncs") if isinstance(payload.get("ncs"), dict) else None),
             external=ExternalAuthConfig.from_mapping(payload.get("external") if isinstance(payload.get("external"), dict) else None),
+            oauth=OAuthAuthConfig.from_mapping(payload.get("oauth") if isinstance(payload.get("oauth"), dict) else None),
         )
 
     def to_mapping(self) -> 'dict[str, Any]':
@@ -234,6 +278,8 @@ class AuthConfig:
             payload["ncs"] = self.ncs.to_mapping()
         if self.external.is_configured():
             payload["external"] = self.external.to_mapping()
+        if self.oauth.is_configured():
+            payload["oauth"] = self.oauth.to_mapping()
         return payload
 
 

--- a/src/maxc_cli/oauth.py
+++ b/src/maxc_cli/oauth.py
@@ -1,0 +1,429 @@
+"""Browser-based OAuth login for MaxCompute, ported from aliyun CLI.
+
+This mirrors the official Alibaba Cloud CLI ``--mode OAuth`` implementation
+(aliyun/aliyun-cli, config/configure.go):
+
+- Authorization Code + PKCE against signin.aliyun.com / signin.alibabacloud.com
+- Local loopback callback server on 127.0.0.1, ports 12345-12349
+- Token exchange / refresh at oauth.aliyun.com / oauth.alibabacloud.com
+- OAuth access token -> temporary STS via POST /v1/exchange
+
+Prerequisite (same as the official CLI): a RAM admin must have installed the
+``official-cli`` OAuth application and assigned identities to the RAM
+users/roles that are allowed to log in this way.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import socket
+import string
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Callable
+
+from .exceptions import ValidationError
+
+# --- Endpoints and client IDs, verbatim from aliyun-cli config/configure.go --
+
+OAUTH_CLIENT_MAP = {
+    "CN": "4038181954557748008",
+    "INTL": "4103531455503354461",
+}
+
+OAUTH_BASE_URL_MAP = {
+    "CN": "https://oauth.aliyun.com",
+    "INTL": "https://oauth.alibabacloud.com",
+}
+
+SIGN_IN_MAP = {
+    "CN": "https://signin.aliyun.com",
+    "INTL": "https://signin.alibabacloud.com",
+}
+
+CALLBACK_PATH = "/cli/callback"
+CALLBACK_PORT_RANGE = (12345, 12349)
+
+# Refresh the cached STS this long before it actually expires.
+STS_REFRESH_BUFFER_SECONDS = 300
+
+_DEFAULT_TIMEOUT_SECONDS = 300
+
+
+@dataclass
+class OAuthTokens:
+    access_token: str
+    refresh_token: str
+    expires_at: int  # unix seconds
+
+
+@dataclass
+class StsCredential:
+    access_key_id: str
+    access_key_secret: str
+    security_token: str
+    expiration_iso: str  # RFC3339, e.g. "2026-08-19T08:00:00Z"
+
+
+class OAuthError(ValidationError):
+    """OAuth flow failed (browser flow, token exchange, or refresh)."""
+
+    error_code = "OAUTH_ERROR"
+
+
+def _validate_site_type(site_type: str) -> str:
+    site = (site_type or "").upper()
+    if site not in ("CN", "INTL"):
+        raise ValidationError(
+            f"Invalid OAuth site type: {site_type!r}, only CN or INTL are supported."
+        )
+    return site
+
+
+# --- PKCE helpers (ported from aliyun-cli generateCodeVerifier/Challenge) ---
+
+_VERIFIER_ALPHABET = string.ascii_letters + string.digits
+
+
+def generate_code_verifier(length: int = 128) -> str:
+    """Random 43-128 char string; aliyun-cli uses 128 alphanumerics."""
+    return "".join(secrets.choice(_VERIFIER_ALPHABET) for _ in range(length))
+
+
+def generate_code_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def detect_port(start: int = CALLBACK_PORT_RANGE[0], end: int = CALLBACK_PORT_RANGE[1]) -> int:
+    for port in range(start, end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+            return port
+    raise OAuthError(f"No available port found in range {start}-{end} for the OAuth callback server.")
+
+
+def build_auth_url(
+    *,
+    site_type: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+    sign_in_url: str | None = None,
+    client_id: str | None = None,
+) -> str:
+    site = _validate_site_type(site_type)
+    base = sign_in_url or SIGN_IN_MAP[site]
+    cid = client_id or OAUTH_CLIENT_MAP[site]
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": cid,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    return f"{base}/oauth2/v1/auth?{query}"
+
+
+# --- HTTP plumbing -----------------------------------------------------------
+
+def _post_form(url: str, data: dict[str, str], *, timeout: float = 30.0) -> dict[str, Any]:
+    body = urllib.parse.urlencode(data).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise OAuthError(f"Token endpoint returned status {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise OAuthError(
+            f"Cannot reach OAuth endpoint {url}: {exc.reason}.",
+            suggestion="Check network connectivity and proxy settings, then retry.",
+        ) from exc
+    return payload
+
+
+def _parse_token_response(payload: dict[str, Any]) -> OAuthTokens:
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise OAuthError("access_token not found in OAuth token response.")
+    expires_in = int(payload.get("expires_in", 0))
+    return OAuthTokens(
+        access_token=access_token,
+        refresh_token=payload.get("refresh_token") or "",
+        expires_at=int(time.time()) + expires_in,
+    )
+
+
+# --- Browser flow ------------------------------------------------------------
+
+def start_oauth_flow(
+    site_type: str = "CN",
+    *,
+    open_browser: bool = True,
+    on_url: Callable[[str], None] | None = None,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    oauth_base_url: str | None = None,
+    sign_in_url: str | None = None,
+    client_id: str | None = None,
+) -> OAuthTokens:
+    """Run the Authorization Code + PKCE flow like ``aliyun configure --mode OAuth``.
+
+    Starts a loopback callback server, presents the sign-in URL (opening the
+    browser unless disabled), waits for the callback, and exchanges the code
+    for tokens. ``on_url`` receives the sign-in URL for custom presentation
+    (e.g. CLI stderr in JSON mode).
+    """
+    site = _validate_site_type(site_type)
+    cid = client_id or OAUTH_CLIENT_MAP[site]
+    base_url = oauth_base_url or OAUTH_BASE_URL_MAP[site]
+
+    port = detect_port()
+    redirect_uri = f"http://127.0.0.1:{port}{CALLBACK_PATH}"
+    state = "".join(secrets.choice(_VERIFIER_ALPHABET) for _ in range(16))
+    code_verifier = generate_code_verifier()
+    code_challenge = generate_code_challenge(code_verifier)
+    auth_url = build_auth_url(
+        site_type=site,
+        redirect_uri=redirect_uri,
+        state=state,
+        code_challenge=code_challenge,
+        sign_in_url=sign_in_url,
+        client_id=client_id,
+    )
+
+    if on_url is not None:
+        on_url(auth_url)
+    if open_browser:
+        # Best effort: on headless machines this silently does nothing.
+        try:
+            webbrowser.open(auth_url)
+        except Exception:
+            pass
+
+    result: dict[str, str] = {}
+    error: dict[str, str] = {}
+    done = threading.Event()
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib naming
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != CALLBACK_PATH:
+                self.send_error(404)
+                return
+            form = urllib.parse.parse_qs(parsed.query)
+            if form.get("state", [""])[0] != state:
+                error["message"] = "invalid state"
+                self.send_error(400, "Invalid state")
+                done.set()
+                return
+            code = form.get("code", [""])[0]
+            if not code:
+                error["message"] = "code not found in callback"
+                self.send_error(400, "Code not found")
+                done.set()
+                return
+            body = b"Authorization successful. You can close this window."
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            result["code"] = code
+            done.set()
+
+        def log_message(self, format, *args):  # noqa: A002 - stdlib naming
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        if not done.wait(timeout=timeout_seconds):
+            raise OAuthError(
+                f"Timed out waiting for the OAuth callback ({int(timeout_seconds)}s).",
+                suggestion="Retry `maxc auth login --oauth` and complete the browser sign-in promptly.",
+            )
+        if error:
+            raise OAuthError(f"OAuth callback failed: {error['message']}")
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+
+    payload = _post_form(
+        f"{base_url}/v1/token",
+        {
+            "grant_type": "authorization_code",
+            "code": result["code"],
+            "client_id": cid,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        },
+    )
+    return _parse_token_response(payload)
+
+
+def refresh_oauth_token(
+    site_type: str,
+    refresh_token: str,
+    *,
+    oauth_base_url: str | None = None,
+    client_id: str | None = None,
+) -> OAuthTokens:
+    """Exchange a refresh token for a new token pair (ported from tryRefreshOauthToken)."""
+    site = _validate_site_type(site_type)
+    if not refresh_token:
+        raise OAuthError(
+            "OAuth refresh token is empty; please re-authenticate.",
+            suggestion="Run `maxc auth login --oauth` to sign in again.",
+        )
+    payload = _post_form(
+        f"{oauth_base_url or OAUTH_BASE_URL_MAP[site]}/v1/token",
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id or OAUTH_CLIENT_MAP[site],
+        },
+    )
+    return _parse_token_response(payload)
+
+
+def exchange_sts(
+    site_type: str,
+    access_token: str,
+    *,
+    oauth_base_url: str | None = None,
+) -> StsCredential:
+    """Trade an OAuth access token for temporary STS credentials (POST /v1/exchange)."""
+    site = _validate_site_type(site_type)
+    if not access_token:
+        raise OAuthError(
+            "OAuth access token is empty; please re-authenticate.",
+            suggestion="Run `maxc auth login --oauth` to sign in again.",
+        )
+    url = f"{oauth_base_url or OAUTH_BASE_URL_MAP[site]}/v1/exchange"
+    req = urllib.request.Request(
+        url,
+        data=b"",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "maxc-cli",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise OAuthError(f"STS exchange failed, status {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise OAuthError(f"Cannot reach OAuth endpoint {url}: {exc.reason}.") from exc
+
+    if not payload.get("accessKeyId"):
+        raise OAuthError(f"STS exchange returned no credentials: {payload}")
+    return StsCredential(
+        access_key_id=payload["accessKeyId"],
+        access_key_secret=payload["accessKeySecret"],
+        security_token=payload["securityToken"],
+        expiration_iso=payload["expiration"],
+    )
+
+
+# --- Cached-credential lifecycle ----------------------------------------------
+
+def _parse_rfc3339(value: str) -> float:
+    from datetime import datetime
+
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text).timestamp()
+
+
+def sts_cache_valid(auth, *, now: float | None = None) -> bool:
+    """True when the cached STS triple in AuthConfig is still usable."""
+    if not (auth.access_id and auth.secret_access_key and auth.security_token):
+        return False
+    if not auth.token_expires_at:
+        return False
+    try:
+        expiry = _parse_rfc3339(auth.token_expires_at)
+    except (ValueError, TypeError):
+        return False
+    current = now if now is not None else time.time()
+    return expiry - STS_REFRESH_BUFFER_SECONDS > current
+
+
+def ensure_oauth_sts(auth, *, config_path: Path | None = None) -> StsCredential:
+    """Return a usable STS credential for an OAuth-configured AuthConfig.
+
+    Order (mirroring aliyun-cli exchangeFromOAuth / tryRefreshOauthToken):
+    1. Cached STS still valid -> use it (no network).
+    2. OAuth access token expired -> refresh it with the refresh token.
+    3. Exchange access token for fresh STS.
+    4. Persist updated tokens back to the config file when a path is given.
+    """
+    if sts_cache_valid(auth):
+        return StsCredential(
+            access_key_id=auth.access_id,
+            access_key_secret=auth.secret_access_key,
+            security_token=auth.security_token,
+            expiration_iso=auth.token_expires_at,
+        )
+
+    oauth = auth.oauth
+    if not oauth.is_configured() or not oauth.site_type:
+        raise OAuthError(
+            "OAuth login is not configured.",
+            suggestion="Run `maxc auth login --oauth` to sign in.",
+        )
+    site = _validate_site_type(oauth.site_type)
+
+    access_token = oauth.access_token or ""
+    if not oauth.access_token_expire or oauth.access_token_expire <= int(time.time()):
+        tokens = refresh_oauth_token(site, oauth.refresh_token or "")
+        oauth.access_token = tokens.access_token
+        oauth.refresh_token = tokens.refresh_token
+        oauth.access_token_expire = tokens.expires_at
+        access_token = tokens.access_token
+
+    sts = exchange_sts(site, access_token)
+
+    # Write exchanged credentials + rotated tokens back, like aliyun-cli does.
+    auth.access_id = sts.access_key_id
+    auth.secret_access_key = sts.access_key_secret
+    auth.security_token = sts.security_token
+    auth.token_expires_at = sts.expiration_iso
+
+    if config_path is not None:
+        from .config import load_config_mapping, save_config_mapping
+
+        payload = load_config_mapping(config_path) if config_path.exists() else {}
+        payload["auth"] = auth.to_mapping()
+        save_config_mapping(config_path, payload)
+
+    return sts

--- a/tests/test_agent_hints_and_cli.py
+++ b/tests/test_agent_hints_and_cli.py
@@ -276,7 +276,10 @@ def test_auth_whoami_without_credentials_returns_guidance(tmp_path: 'Path', monk
     # command_id removed in v0.1.6+
     assert payload["data"]["identity"]["authenticated"] is False
     assert payload["data"]["identity"]["configured"] is False
-    assert payload["data"]["auth_options"][0]["command"] == "auth login --from-env"
+    # OAuth is the recommended login mode; AK remains available.
+    auth_commands = [opt["command"] for opt in payload["data"]["auth_options"]]
+    assert auth_commands[0] == "auth login --oauth"
+    assert "auth login --from-env" in auth_commands
 
 
 def test_meta_list_projects_hints_use_existing_commands(tmp_path: 'Path') -> 'None':

--- a/tests/test_cli_mock.py
+++ b/tests/test_cli_mock.py
@@ -357,7 +357,10 @@ allowed_operations:
     assert payload["data"]["identity"]["authenticated"] is False
     assert payload["data"]["identity"]["configured"] is False
     assert payload["data"]["identity"]["validation_status"] == "missing_configuration"
-    assert payload["data"]["auth_options"][0]["type"] == "access_key"
+    assert payload["data"]["auth_options"][0]["type"] == "oauth"
+    assert any(
+        option["type"] == "access_key" for option in payload["data"]["auth_options"]
+    )
 
 
 def test_auth_whoami_marks_configured_but_unverified_when_remote_check_fails(

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,376 @@
+"""Tests for the OAuth login flow (ported from aliyun CLI --mode OAuth)."""
+
+import json
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from maxc_cli import oauth
+from maxc_cli.config import AuthConfig, OAuthAuthConfig
+from maxc_cli.oauth import (
+    OAuthError,
+    build_auth_url,
+    detect_port,
+    ensure_oauth_sts,
+    exchange_sts,
+    generate_code_challenge,
+    generate_code_verifier,
+    refresh_oauth_token,
+    start_oauth_flow,
+    sts_cache_valid,
+)
+
+
+# --- PKCE --------------------------------------------------------------------
+
+def test_code_verifier_is_128_alnum() -> None:
+    verifier = generate_code_verifier()
+    assert len(verifier) == 128
+    assert verifier.isalnum()
+
+
+def test_code_challenge_matches_rfc7636_vector() -> None:
+    # RFC 7636 appendix B known answer.
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    assert generate_code_challenge(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+# --- URL / port ----------------------------------------------------------------
+
+def test_build_auth_url_contains_pkce_parameters() -> None:
+    url = build_auth_url(
+        site_type="CN",
+        redirect_uri="http://127.0.0.1:12345/cli/callback",
+        state="abc123",
+        code_challenge="challenge",
+    )
+    assert url.startswith("https://signin.aliyun.com/oauth2/v1/auth?")
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    assert query["response_type"] == ["code"]
+    assert query["client_id"] == [oauth.OAUTH_CLIENT_MAP["CN"]]
+    assert query["redirect_uri"] == ["http://127.0.0.1:12345/cli/callback"]
+    assert query["state"] == ["abc123"]
+    assert query["code_challenge"] == ["challenge"]
+    assert query["code_challenge_method"] == ["S256"]
+
+
+def test_build_auth_url_intl_uses_intl_endpoints() -> None:
+    url = build_auth_url(
+        site_type="INTL",
+        redirect_uri="http://127.0.0.1:12345/cli/callback",
+        state="s",
+        code_challenge="c",
+    )
+    assert url.startswith("https://signin.alibabacloud.com/oauth2/v1/auth?")
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+    assert query["client_id"] == [oauth.OAUTH_CLIENT_MAP["INTL"]]
+
+
+def test_build_auth_url_rejects_bad_site_type() -> None:
+    with pytest.raises(Exception):
+        build_auth_url(site_type="XX", redirect_uri="u", state="s", code_challenge="c")
+
+
+def test_detect_port_returns_port_in_range() -> None:
+    port = detect_port()
+    assert 12345 <= port <= 12349
+
+
+# --- Fake OAuth server -----------------------------------------------------------
+
+class _FakeOAuthServer:
+    """Serves /v1/token and /v1/exchange on a loopback port."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.handler = HTTPServer(("127.0.0.1", 0), self._make_handler())
+        self.port = self.handler.server_address[1]
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self.thread = threading.Thread(target=self.handler.serve_forever, daemon=True)
+        self.thread.start()
+
+    def _make_handler(self):
+        requests = self.requests
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length).decode("utf-8")
+                requests.append(
+                    {
+                        "path": self.path,
+                        "body": body,
+                        "authorization": self.headers.get("Authorization"),
+                    }
+                )
+                if self.path == "/v1/token":
+                    form = urllib.parse.parse_qs(body)
+                    grant = form.get("grant_type", [""])[0]
+                    if grant == "authorization_code":
+                        payload = {
+                            "access_token": "at-1",
+                            "refresh_token": "rt-1",
+                            "expires_in": 3600,
+                            "token_type": "Bearer",
+                        }
+                    elif grant == "refresh_token":
+                        payload = {
+                            "access_token": "at-2",
+                            "refresh_token": "rt-2",
+                            "expires_in": 3600,
+                            "token_type": "Bearer",
+                        }
+                    else:
+                        self.send_error(400, "bad grant")
+                        return
+                elif self.path == "/v1/exchange":
+                    payload = {
+                        "requestId": "req-1",
+                        "accessKeyId": "STS.AKID",
+                        "accessKeySecret": "STSSECRET",
+                        "securityToken": "STSTOKEN",
+                        "expiration": "2099-01-01T00:00:00Z",
+                    }
+                else:
+                    self.send_error(404)
+                    return
+                data = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, format, *args):  # noqa: A002
+                pass
+
+        return Handler
+
+    def stop(self) -> None:
+        self.handler.shutdown()
+        self.handler.server_close()
+        self.thread.join(timeout=5)
+
+
+@pytest.fixture
+def fake_oauth():
+    server = _FakeOAuthServer()
+    yield server
+    server.stop()
+
+
+# --- Token endpoints -----------------------------------------------------------
+
+def test_refresh_oauth_token_posts_refresh_grant(fake_oauth: _FakeOAuthServer) -> None:
+    tokens = refresh_oauth_token("CN", "rt-old", oauth_base_url=fake_oauth.base_url)
+    assert tokens.access_token == "at-2"
+    assert tokens.refresh_token == "rt-2"
+    assert tokens.expires_at > 0
+
+    form = urllib.parse.parse_qs(fake_oauth.requests[0]["body"])
+    assert form["grant_type"] == ["refresh_token"]
+    assert form["refresh_token"] == ["rt-old"]
+    assert form["client_id"] == [oauth.OAUTH_CLIENT_MAP["CN"]]
+
+
+def test_refresh_oauth_token_empty_refresh_token_raises() -> None:
+    with pytest.raises(OAuthError):
+        refresh_oauth_token("CN", "")
+
+
+def test_exchange_sts_sends_bearer_and_parses_response(fake_oauth: _FakeOAuthServer) -> None:
+    sts = exchange_sts("CN", "at-1", oauth_base_url=fake_oauth.base_url)
+    assert sts.access_key_id == "STS.AKID"
+    assert sts.access_key_secret == "STSSECRET"
+    assert sts.security_token == "STSTOKEN"
+    assert sts.expiration_iso == "2099-01-01T00:00:00Z"
+    assert fake_oauth.requests[0]["authorization"] == "Bearer at-1"
+
+
+# --- Full browser flow -----------------------------------------------------------
+
+def test_start_oauth_flow_end_to_end(fake_oauth: _FakeOAuthServer) -> None:
+    captured: dict[str, str] = {}
+
+    def simulate_browser(url: str) -> None:
+        captured["url"] = url
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        redirect_uri = query["redirect_uri"][0]
+        state = query["state"][0]
+        callback = f"{redirect_uri}?code=authcode-1&state={urllib.parse.quote(state)}"
+
+        def hit_callback() -> None:
+            import time
+            import urllib.error
+            import urllib.request
+
+            # The callback server starts right after on_url returns; retry
+            # until it is listening instead of racing its startup.
+            for _ in range(50):
+                try:
+                    urllib.request.urlopen(callback, timeout=5).read()
+                    return
+                except urllib.error.URLError:
+                    time.sleep(0.1)
+
+        threading.Thread(target=hit_callback, daemon=True).start()
+
+    tokens = start_oauth_flow(
+        "CN",
+        open_browser=False,
+        on_url=simulate_browser,
+        oauth_base_url=fake_oauth.base_url,
+        sign_in_url=fake_oauth.base_url,  # only the URL shape matters here
+        timeout_seconds=15,
+    )
+
+    assert tokens.access_token == "at-1"
+    assert tokens.refresh_token == "rt-1"
+
+    # The code exchange must carry PKCE material.
+    token_posts = [r for r in fake_oauth.requests if r["path"] == "/v1/token"]
+    assert len(token_posts) == 1
+    form = urllib.parse.parse_qs(token_posts[0]["body"])
+    assert form["grant_type"] == ["authorization_code"]
+    assert form["code"] == ["authcode-1"]
+    assert form["code_verifier"][0] != ""
+    assert form["client_id"] == [oauth.OAUTH_CLIENT_MAP["CN"]]
+
+    # The auth URL itself carried the S256 challenge derived from the verifier.
+    auth_query = urllib.parse.parse_qs(urllib.parse.urlparse(captured["url"]).query)
+    assert auth_query["code_challenge"][0] == generate_code_challenge(form["code_verifier"][0])
+    assert auth_query["code_challenge_method"] == ["S256"]
+
+
+def test_start_oauth_flow_times_out_without_callback(fake_oauth: _FakeOAuthServer) -> None:
+    with pytest.raises(OAuthError, match="Timed out"):
+        start_oauth_flow(
+            "CN",
+            open_browser=False,
+            oauth_base_url=fake_oauth.base_url,
+            sign_in_url=fake_oauth.base_url,
+            timeout_seconds=0.5,
+        )
+
+
+# --- STS cache lifecycle -----------------------------------------------------------
+
+def _oauth_auth(**overrides) -> AuthConfig:
+    auth = AuthConfig(
+        provider="oauth",
+        access_id="CACHED.AK",
+        secret_access_key="CACHEDSECRET",
+        security_token="CACHEDTOKEN",
+        token_expires_at="2099-01-01T00:00:00Z",
+        project="p",
+        endpoint="e",
+        oauth=OAuthAuthConfig(
+            site_type="CN",
+            access_token="at-cached",
+            refresh_token="rt-cached",
+            access_token_expire=9_999_999_999,
+        ),
+    )
+    for key, value in overrides.items():
+        setattr(auth, key, value)
+    return auth
+
+
+def test_sts_cache_valid_accepts_future_expiry() -> None:
+    assert sts_cache_valid(_oauth_auth()) is True
+
+
+def test_sts_cache_valid_rejects_expired_or_missing() -> None:
+    assert sts_cache_valid(_oauth_auth(token_expires_at="2000-01-01T00:00:00Z")) is False
+    assert sts_cache_valid(_oauth_auth(token_expires_at=None)) is False
+    assert sts_cache_valid(_oauth_auth(security_token=None)) is False
+    assert sts_cache_valid(_oauth_auth(token_expires_at="not-a-date")) is False
+
+
+def test_ensure_oauth_sts_uses_cache_without_network(fake_oauth: _FakeOAuthServer) -> None:
+    sts = ensure_oauth_sts(_oauth_auth(), config_path=None)
+    assert sts.access_key_id == "CACHED.AK"
+    assert fake_oauth.requests == []
+
+
+def test_ensure_oauth_sts_refreshes_and_persists(
+    fake_oauth: _FakeOAuthServer, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(oauth.OAUTH_BASE_URL_MAP, "CN", fake_oauth.base_url)
+    auth = _oauth_auth(
+        access_id="OLD.AK",
+        secret_access_key="OLDSECRET",
+        security_token="OLDTOKEN",
+        token_expires_at="2000-01-01T00:00:00Z",  # STS expired
+        oauth=OAuthAuthConfig(
+            site_type="CN",
+            access_token="at-old",
+            refresh_token="rt-old",
+            access_token_expire=1,  # access token expired -> refresh first
+        ),
+    )
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("auth:\n  provider: oauth\n", encoding="utf-8")
+
+    sts = ensure_oauth_sts(auth, config_path=config_file)
+
+    assert sts.access_key_id == "STS.AKID"
+    # refresh then exchange
+    assert [r["path"] for r in fake_oauth.requests] == ["/v1/token", "/v1/exchange"]
+    # exchanged credentials + rotated tokens persisted
+    saved = config_file.read_text(encoding="utf-8")
+    assert "STS.AKID" in saved
+    assert "rt-2" in saved
+    assert "2099-01-01T00:00:00Z" in saved
+
+
+def test_ensure_oauth_sts_without_oauth_config_raises() -> None:
+    auth = AuthConfig(provider="oauth")
+    with pytest.raises(OAuthError):
+        ensure_oauth_sts(auth, config_path=None)
+
+
+# --- Config round-trip -----------------------------------------------------------
+
+def test_auth_config_oauth_round_trip() -> None:
+    auth = _oauth_auth()
+    mapping = auth.to_mapping()
+    assert mapping["oauth"]["site_type"] == "CN"
+    assert mapping["oauth"]["access_token"] == "at-cached"
+    assert mapping["oauth"]["access_token_expire"] == 9_999_999_999
+
+    restored = AuthConfig.from_mapping(mapping)
+    assert restored.provider == "oauth"
+    assert restored.oauth.is_configured()
+    assert restored.oauth.refresh_token == "rt-cached"
+
+
+# --- Provider inference & CLI parsing -----------------------------------------------------------
+
+def test_infer_auth_provider_prefers_oauth_over_cached_sts(tmp_path: Path) -> None:
+    from maxc_cli.auth_providers import infer_auth_provider, resolve_odps_settings
+
+    from tests.test_job_improvements import make_app
+
+    app = make_app(tmp_path)
+    app.config.auth = _oauth_auth()
+    settings, _, _ = resolve_odps_settings(app.config)
+    # Cached STS triple must not shadow the OAuth provider.
+    assert infer_auth_provider(app.config, settings) == "oauth"
+
+
+def test_auth_login_oauth_flags_parse(tmp_path: Path) -> None:
+    from maxc_cli.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["auth", "login", "--oauth", "--site-type", "INTL", "--no-browser"])
+    assert args.oauth is True
+    assert args.site_type == "INTL"
+    assert args.no_browser is True
+
+    default_args = parser.parse_args(["auth", "login"])
+    assert default_args.oauth is False
+    assert default_args.site_type == "CN"


### PR DESCRIPTION
## What

Port the aliyun CLI OAuth mode (Authorization Code + PKCE) to maxc, equivalent to `aliyun configure --mode OAuth`.

## Changes

- **`maxc_cli/oauth.py`** (new): PKCE (S256) flow with a local loopback callback server (ports 12345-12349), authorization-code exchange, automatic refresh-token renewal, and token-to-STS exchange with caching.
- **`auth login --oauth`**: browser-based login, with `--site-type CN|INTL` and `--no-browser` for headless agents; the sign-in URL is printed to stderr in `--json` mode so stdout stays a single clean envelope.
- **`OAuthAuthConfig`**: persisted in the existing maxc config file; no new configuration is required from users.
- **auth_providers**: resolve the `oauth` provider into an `StsAccount` for PyODPS, refreshing expired tokens transparently.
- **`auth whoami`**: guidance now lists OAuth as the primary auth option, matching aliyun CLI's recommended mode.

## Tests

- `tests/test_oauth.py` (new): PKCE generation, authorize-URL construction, token exchange, end-to-end callback flow, refresh, STS caching, and provider inference.
- Full suite: 692 passed (the single failure, `test_cli_readonly_error_has_agent_hints`, also fails on the base commit and is unrelated).

## Usage

```bash
maxc auth login --oauth            # opens the browser
maxc auth login --oauth --no-browser   # headless: prints sign-in URL
```

Credentials refresh automatically afterwards; no config changes needed.